### PR TITLE
Reply/Retweet checkboxes

### DIFF
--- a/web/step1.php
+++ b/web/step1.php
@@ -67,6 +67,8 @@ if ( $ret == "AUTH_ERR" ) {
 <tr>
 <td>Twitter username:</td>
 <td><input type="text" name="username"></td>
+<td><input type="checkbox" name="retweet" value="Retweet" checked>Retweets<br>
+<input type="checkbox" name="reply" value="Reply">Replies</td>
 <td><input type="submit" value="Submit"></td>
 </tr>
 </table>

--- a/web/step2.php
+++ b/web/step2.php
@@ -53,10 +53,12 @@ if (strlen($username) < 1) {
 // send username to backend
 fwrite($sock, 'USER '.$username."\n");
 
-// these variables should be grabbed from post at a later date.
-// for now, use these defaults.
-fwrite($sock, "RT 1\n");
-fwrite($sock, "REPLY 0\n");
+    // Check RT/REPLY values from form submission
+    $retweet = (isset($_POST[retweet]) && $_POST[retweet] == "Retweet") ? 1 : 0;
+    $reply = (isset($_POST[reply]) && $_POST[reply] == "Reply") ? 1 : 0;
+
+fwrite($sock, "RT $retweet\n");
+fwrite($sock, "REPLY $reply\n");
 
 // kick off the backend processing
 fwrite($sock, "GO\n");


### PR DESCRIPTION
Add checkboxes to step1 form submission for Reply/Retweet. Retweet defaults to checked.

Check for values in step2. If values are passed, set to 1, otherwise 0.