### PR TITLE
Twitter block rollout

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -47,7 +47,7 @@ table {
 
  <h2>How it works</h2>
 
- <p>After logging into twitter, you will be asked to enter a username that is the source of unwanted attention toward you. Shields Up will gather a list of accounts that may be likely to follow a dogpile request, based on followers, retweets, and/or replies. You will then be prompted to download a list of user ids that can be imported via Twitter's new <a href="https://blog.twitter.com/2015/sharing-block-lists-to-help-make-twitter-safer">block import</a>.</p>
+ <p>After logging into twitter, you will be asked to enter a username that is the source of unwanted attention toward you. Shields Up will gather a list of accounts that may be likely to follow a dogpile request, based on followers, retweets, and/or replies. You will then be prompted to download a list of user ids that can be imported via Twitter's <a href="https://blog.twitter.com/2015/sharing-block-lists-to-help-make-twitter-safer">new block import</a>, available from your <a href="https://twitter.com/settings/blocked">Twitter Settings</a> page.</p>
 
  <p>Shields Up is an Open Source project by OAPI. The backend is Ruby and the frontend is PHP. Feel free to review/contribute at <a href="https://github.com/oapi/shieldsup">https://github.com/oapi/shieldsup</a>.
 

--- a/web/index.html
+++ b/web/index.html
@@ -47,7 +47,7 @@ table {
 
  <h2>How it works</h2>
 
- <p>After logging into twitter, you will be asked to enter a username that is the source of unwanted attention toward you. Shields Up will gather a list of accounts that may be likely to follow a dogpile request, based on followers, retweets, and/or replies. You will then be prompted to download a list of user ids that can be imported via Twitter's <a href="https://blog.twitter.com/2015/sharing-block-lists-to-help-make-twitter-safer">new block import</a>, available from your <a href="https://twitter.com/settings/blocked">Twitter Settings</a> page.</p>
+ <p>After logging into twitter, you will be asked to enter a username that is the source of unwanted attention toward you. Shields Up will gather a list of accounts that may be likely to follow a dogpile request, based on followers, retweets, and/or replies. You will then be prompted to download a list of user ids that can be imported via Twitter's <a href="https://blog.twitter.com/2015/sharing-block-lists-to-help-make-twitter-safer">new block import</a>, available from your <a href="https://twitter.com/settings/blocked">Twitter Settings</a> page. Note that the rollout is expected to take several weeks; you may not have this option available yet.</p>
 
  <p>Shields Up is an Open Source project by OAPI. The backend is Ruby and the frontend is PHP. Feel free to review/contribute at <a href="https://github.com/oapi/shieldsup">https://github.com/oapi/shieldsup</a>.
 


### PR DESCRIPTION
The twitter block import is being phased in over a period of a few weeks. Add a direct link, as well as a note that it might not be available to everyone. The note is in a commit that can (and should) be reverted in a few weeks.