### PR TITLE
Oauth cleanup

### DIFF
--- a/web/twitter_oauth.php
+++ b/web/twitter_oauth.php
@@ -31,13 +31,13 @@ if(!empty($_GET['oauth_verifier']) && !empty($_SESSION['oauth_token']) && !empty
         if (!$db_selected) die ('Could not connect to DB:' . mysql_error());
 
         // Let's find the user by its ID
-		$query = sprintf("SELECT id, userid, oauth_token, oauth_secret FROM tokens WHERE userid = '%s'". mysql_real_escape_string($user_info->id));
+		$query = sprintf("SELECT id, userid, oauth_token, oauth_secret FROM tokens WHERE userid = '%d'", mysql_real_escape_string($user_info->id));
         $result = mysql_query($query, $link);
 
  
 		// If not, let's add it to the database
 		if(mysql_num_rows($result) == 0){
-			$query = sprintf("INSERT INTO tokens (userid, oauth_token, oauth_secret, added) VALUES ('%s', '%s', '%s', NOW())",mysql_real_escape_string($user_info->id), mysql_real_escape_string($access_token['oauth_token']), mysql_real_escape_string($access_token['oauth_token_secret']));
+			$query = sprintf("INSERT INTO tokens (userid, oauth_token, oauth_secret, added) VALUES ('%d', '%s', '%s', NOW())",mysql_real_escape_string($user_info->id), mysql_real_escape_string($access_token['oauth_token']), mysql_real_escape_string($access_token['oauth_token_secret']));
             $result = mysql_query($query, $link);
             if(!$result) die("Problems writing to the database");
 
@@ -45,7 +45,7 @@ if(!empty($_GET['oauth_verifier']) && !empty($_SESSION['oauth_token']) && !empty
 
         } else {
 			// Update the tokens
-			$query = sprintf("UPDATE tokens SET oauth_token = '%s', oauth_secret = '%s', accessed = NOW() WHERE userid = '%s'", mysql_real_escape_string($access_token['oauth_token']), mysql_real_escape_string($access_token['oauth_token_secret']), mysql_real_escape_string($user_info->id));
+			$query = sprintf("UPDATE tokens SET oauth_token = '%s', oauth_secret = '%s', accessed = NOW() WHERE userid = '%d'", mysql_real_escape_string($access_token['oauth_token']), mysql_real_escape_string($access_token['oauth_token_secret']), mysql_real_escape_string($user_info->id));
             mysql_query($query, $link); // We don't want to overwrite this $result.
 		}
 

--- a/web/twitter_oauth.php
+++ b/web/twitter_oauth.php
@@ -19,7 +19,7 @@ if(!empty($_GET['oauth_verifier']) && !empty($_SESSION['oauth_token']) && !empty
     // User id might be 0 if we've capped out on API requests.
 	if(!isset($user_info->id) || $user_info->id == 0 || !is_numeric($user_info->id)){
         die("API rate limit exceeded. Please try again later.");
-        
+
     } else if (isset($user_info->error)){
 		// Something's wrong, go back to square 1
 		header('Location: twitter_login.php');
@@ -35,16 +35,17 @@ if(!empty($_GET['oauth_verifier']) && !empty($_SESSION['oauth_token']) && !empty
 
         // Let's find the user by its ID
 		$query = sprintf("SELECT id, userid, oauth_token, oauth_secret FROM tokens WHERE userid = '%d'", mysql_real_escape_string($user_info->id));
-        $result = mysql_query($query, $link);
+        $query_result = mysql_query($query, $link);
+        if(!$query_result) die ("Error querying database: ". mysql_error());
 
  
 		// If not, let's add it to the database
-		if(mysql_num_rows($result) == 0){
+		if(mysql_num_rows($query_result) == 0){
 			$query = sprintf("INSERT INTO tokens (userid, oauth_token, oauth_secret, added) VALUES ('%d', '%s', '%s', NOW())",mysql_real_escape_string($user_info->id), mysql_real_escape_string($access_token['oauth_token']), mysql_real_escape_string($access_token['oauth_token_secret']));
             $result = mysql_query($query, $link);
             if(!$result) die("Problems writing to the database");
 
-			$query = mysql_query("SELECT id, userid, oauth_token, oauth_secret FROM tokens WHERE id = " . mysql_insert_id(), $link);
+			$query_result = mysql_query("SELECT id, userid, oauth_token, oauth_secret FROM tokens WHERE id = " . mysql_insert_id(), $link);
 
         } else {
 			// Update the tokens
@@ -52,7 +53,7 @@ if(!empty($_GET['oauth_verifier']) && !empty($_SESSION['oauth_token']) && !empty
             mysql_query($query, $link); // We don't want to overwrite this $result.
 		}
 
-        $result = mysql_fetch_array($query);
+        $result = mysql_fetch_array($query_result);
 
         $_SESSION['access_token'] = $access_token;
 		$_SESSION['id'] = $result['id'];

--- a/web/twitter_oauth.php
+++ b/web/twitter_oauth.php
@@ -33,22 +33,23 @@ if(!empty($_GET['oauth_verifier']) && !empty($_SESSION['oauth_token']) && !empty
         // Let's find the user by its ID
 		$query = sprintf("SELECT id, userid, oauth_token, oauth_secret FROM tokens WHERE userid = '%s'". mysql_real_escape_string($user_info->id));
         $result = mysql_query($query, $link);
-        $result = mysql_fetch_array($query);
+
  
 		// If not, let's add it to the database
-		if(empty($result)){
+		if(mysql_num_rows($result) == 0){
 			$query = sprintf("INSERT INTO tokens (userid, oauth_token, oauth_secret, added) VALUES ('%s', '%s', '%s', NOW())",mysql_real_escape_string($user_info->id), mysql_real_escape_string($access_token['oauth_token']), mysql_real_escape_string($access_token['oauth_token_secret']));
             $result = mysql_query($query, $link);
             if(!$result) die("Problems writing to the database");
 
 			$query = mysql_query("SELECT id, userid, oauth_token, oauth_secret FROM tokens WHERE id = " . mysql_insert_id(), $link);
-			$result = mysql_fetch_array($query);
 
         } else {
 			// Update the tokens
 			$query = sprintf("UPDATE tokens SET oauth_token = '%s', oauth_secret = '%s', accessed = NOW() WHERE userid = '%s'", mysql_real_escape_string($access_token['oauth_token']), mysql_real_escape_string($access_token['oauth_token_secret']), mysql_real_escape_string($user_info->id));
             mysql_query($query, $link); // We don't want to overwrite this $result.
 		}
+
+        $result = mysql_fetch_array($query);
 
         $_SESSION['access_token'] = $access_token;
 		$_SESSION['id'] = $result['id'];

--- a/web/twitter_oauth.php
+++ b/web/twitter_oauth.php
@@ -20,7 +20,7 @@ if(!empty($_GET['oauth_verifier']) && !empty($_SESSION['oauth_token']) && !empty
 	if(!isset($user_info->id) || $user_info->id == 0 || !is_numeric($user_info->id)){
         die("API rate limit exceeded. Please try again later.");
 
-    } else if (isset($user_info->error)){
+    } else if (isset($user_info->errors)){
 		// Something's wrong, go back to square 1
 		header('Location: twitter_login.php');
 

--- a/web/twitter_oauth.php
+++ b/web/twitter_oauth.php
@@ -17,7 +17,10 @@ if(!empty($_GET['oauth_verifier']) && !empty($_SESSION['oauth_token']) && !empty
 	$user_info = $twitteroauth->get('account/verify_credentials');
 
     // User id might be 0 if we've capped out on API requests.
-	if(isset($user_info->error) || $user_info->id == 0 || !is_numeric($user_info->id)){
+	if(!isset($user_info->id) || $user_info->id == 0 || !is_numeric($user_info->id)){
+        die("API rate limit exceeded. Please try again later.");
+        
+    } else if (isset($user_info->error)){
 		// Something's wrong, go back to square 1
 		header('Location: twitter_login.php');
 

--- a/web/twitter_oauth.php
+++ b/web/twitter_oauth.php
@@ -28,7 +28,7 @@ if(!empty($_GET['oauth_verifier']) && !empty($_SESSION['oauth_token']) && !empty
     // Let's get the user's info
 	$user_info = $twitteroauth->get('account/verify_credentials');
 
-	if(isset($user_info->error)){
+	if(isset($user_info->error) || $user_info->id == 0 || !is_numeric($user_info->id)){
 		// Something's wrong, go back to square 1
 		header('Location: twitter_login.php');
 

--- a/web/twitter_oauth.php
+++ b/web/twitter_oauth.php
@@ -16,11 +16,7 @@ if(!empty($_GET['oauth_verifier']) && !empty($_SESSION['oauth_token']) && !empty
     // Let's get the user's info
 	$user_info = $twitteroauth->get('account/verify_credentials');
 
-    // User id might be 0 if we've capped out on API requests.
-	if(!isset($user_info->id) || $user_info->id == 0 || !is_numeric($user_info->id)){
-        die("API rate limit exceeded. Please try again later.");
-
-    } else if (isset($user_info->errors)){
+    if (isset($user_info->errors)){
 		// Something's wrong, go back to square 1
 		header('Location: twitter_login.php');
 

--- a/web/twitter_oauth.php
+++ b/web/twitter_oauth.php
@@ -1,60 +1,62 @@
 <?php
 
-include("conf.php");
-
-mysql_connect($db_host, $db_user, $db_pass);
-mysql_select_db($db_name);
-
-require "twitteroauth/twitteroauth.php";
+require("conf.php");
+require("twitteroauth/twitteroauth.php");
 
 session_start();
 
-// THIS IS THE UGLIEST CODE EVER BUT SOMEONE ELSE WROTE IT SO I DON'T FEEL BAD.
-// regardless, we should still fix it.
-// seriously i can barely read this crap.
-
 if(!empty($_GET['oauth_verifier']) && !empty($_SESSION['oauth_token']) && !empty($_SESSION['oauth_token_secret'])){
 
-    // We've got everything we need
 	// TwitterOAuth instance, with two new parameters we got in twitter_login.php
 	$twitteroauth = new TwitterOAuth($app_key, $app_secret, $_SESSION['oauth_token'], $_SESSION['oauth_token_secret']);
 
     // Let's request the access token
 	$access_token = $twitteroauth->getAccessToken($_GET['oauth_verifier']);
 
-    // Save it in a session var
-	$_SESSION['access_token'] = $access_token;
-
     // Let's get the user's info
 	$user_info = $twitteroauth->get('account/verify_credentials');
 
+    // User id might be 0 if we've capped out on API requests.
 	if(isset($user_info->error) || $user_info->id == 0 || !is_numeric($user_info->id)){
 		// Something's wrong, go back to square 1
 		header('Location: twitter_login.php');
 
     } else {
-		// Let's find the user by its ID
-		// todo: error checking?! sanitize.
-		$query = mysql_query("SELECT * FROM tokens WHERE userid = ". $user_info->id);
-		$result = mysql_fetch_array($query);
+
+        // TODO: This needs to get updated to MySQLi or PDO_MySQL
+
+        $link = mysql_connect($db_host, $db_user, $db_pass);
+        if (!$link) die('Could not connect: ' . mysql_error());
+        $db_selected = mysql_select_db($db_name, $link);
+        if (!$db_selected) die ('Could not connect to DB:' . mysql_error());
+
+        // Let's find the user by its ID
+		$query = sprintf("SELECT id, userid, oauth_token, oauth_secret FROM tokens WHERE userid = '%s'". mysql_real_escape_string($user_info->id));
+        $result = mysql_query($query, $link);
+        $result = mysql_fetch_array($query);
  
 		// If not, let's add it to the database
 		if(empty($result)){
-			// todo: this needs to be sanitized.
-			$query = mysql_query("INSERT INTO tokens (userid, oauth_token, oauth_secret, added) VALUES ('{$user_info->id}', '{$access_token['oauth_token']}', '{$access_token['oauth_token_secret']}', NOW())");
-			$query = mysql_query("SELECT * FROM tokens WHERE id = " . mysql_insert_id());
+			$query = sprintf("INSERT INTO tokens (userid, oauth_token, oauth_secret, added) VALUES ('%s', '%s', '%s', NOW())",mysql_real_escape_string($user_info->id), mysql_real_escape_string($access_token['oauth_token']), mysql_real_escape_string($access_token['oauth_token_secret']));
+            $result = mysql_query($query, $link);
+            if(!$result) die("Problems writing to the database");
+
+			$query = mysql_query("SELECT id, userid, oauth_token, oauth_secret FROM tokens WHERE id = " . mysql_insert_id(), $link);
 			$result = mysql_fetch_array($query);
 
         } else {
 			// Update the tokens
-			$query = mysql_query("UPDATE tokens SET oauth_token = '{$access_token['oauth_token']}', oauth_secret = '{$access_token['oauth_token_secret']}', accessed = NOW() WHERE userid = {$user_info->id}");
+			$query = sprintf("UPDATE tokens SET oauth_token = '%s', oauth_secret = '%s', accessed = NOW() WHERE userid = '%s'", mysql_real_escape_string($access_token['oauth_token']), mysql_real_escape_string($access_token['oauth_token_secret']), mysql_real_escape_string($user_info->id));
+            mysql_query($query, $link); // We don't want to overwrite this $result.
 		}
- 
+
+        $_SESSION['access_token'] = $access_token;
 		$_SESSION['id'] = $result['id'];
 		$_SESSION['oauth_uid'] = $result['userid'];
 		$_SESSION['oauth_token'] = $result['oauth_token'];
 		$_SESSION['oauth_token_secret'] = $result['oauth_secret'];
- 
+
+        mysql_close($link);
 		header('Location: step1.php');
 	}
 } else {

--- a/web/twitter_oauth.php
+++ b/web/twitter_oauth.php
@@ -14,20 +14,25 @@ session_start();
 // seriously i can barely read this crap.
 
 if(!empty($_GET['oauth_verifier']) && !empty($_SESSION['oauth_token']) && !empty($_SESSION['oauth_token_secret'])){
-	// We've got everything we need
+
+    // We've got everything we need
 	// TwitterOAuth instance, with two new parameters we got in twitter_login.php
 	$twitteroauth = new TwitterOAuth($app_key, $app_secret, $_SESSION['oauth_token'], $_SESSION['oauth_token_secret']);
-	// Let's request the access token
+
+    // Let's request the access token
 	$access_token = $twitteroauth->getAccessToken($_GET['oauth_verifier']);
-	// Save it in a session var
+
+    // Save it in a session var
 	$_SESSION['access_token'] = $access_token;
-	// Let's get the user's info
+
+    // Let's get the user's info
 	$user_info = $twitteroauth->get('account/verify_credentials');
 
 	if(isset($user_info->error)){
 		// Something's wrong, go back to square 1
 		header('Location: twitter_login.php');
-	} else {
+
+    } else {
 		// Let's find the user by its ID
 		// todo: error checking?! sanitize.
 		$query = mysql_query("SELECT * FROM tokens WHERE userid = ". $user_info->id);
@@ -39,7 +44,8 @@ if(!empty($_GET['oauth_verifier']) && !empty($_SESSION['oauth_token']) && !empty
 			$query = mysql_query("INSERT INTO tokens (userid, oauth_token, oauth_secret, added) VALUES ('{$user_info->id}', '{$access_token['oauth_token']}', '{$access_token['oauth_token_secret']}', NOW())");
 			$query = mysql_query("SELECT * FROM tokens WHERE id = " . mysql_insert_id());
 			$result = mysql_fetch_array($query);
-		} else {
+
+        } else {
 			// Update the tokens
 			$query = mysql_query("UPDATE tokens SET oauth_token = '{$access_token['oauth_token']}', oauth_secret = '{$access_token['oauth_token_secret']}', accessed = NOW() WHERE userid = {$user_info->id}");
 		}


### PR DESCRIPTION
Overhaul mysql queries, adding old style "parameterized" queries with sprintf and mysql_real_escape_strings.
Should no longer create duplicate entries for a given userid (mostly seen with API rate limit problems).
Should no longer end up in a refresh loop (again mostly an API rate limit issue).

Added some mysql error checking.
Added error checking on user ID which should catch some API limit issues.
Move MySQL connect down to where it's first needed; avoids opening in some error cases.
Moved session variable set for access_token down to where we're sure it's valid.
Changed 'select *...' to actually specify columns needed.
Changed an include to require.

NOTE: This needs to be converted to MySQLi or PDO_MySQL.