### PR TITLE
Manage Ruby dependencies via bundler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ conf.php
 *.db
 *.swp
 *.swo
-Gemfile.lock
 log/*
 pkg/*
 tmp/*

--- a/bin/Gemfile
+++ b/bin/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'logger'
+gem 'twitter'
+gem 'mysql2'

--- a/bin/Gemfile.lock
+++ b/bin/Gemfile.lock
@@ -1,0 +1,39 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.3.8)
+    buftok (0.2.0)
+    equalizer (0.0.11)
+    faraday (0.9.1)
+      multipart-post (>= 1.2, < 3)
+    http (0.6.4)
+      http_parser.rb (~> 0.6.0)
+    http_parser.rb (0.6.0)
+    json (1.8.3)
+    logger (1.2.8)
+    memoizable (0.4.2)
+      thread_safe (~> 0.3, >= 0.3.1)
+    multipart-post (2.0.0)
+    mysql2 (0.3.18)
+    naught (1.0.0)
+    simple_oauth (0.3.1)
+    thread_safe (0.3.5)
+    twitter (5.14.0)
+      addressable (~> 2.3)
+      buftok (~> 0.2.0)
+      equalizer (~> 0.0.9)
+      faraday (~> 0.9.0)
+      http (~> 0.6.0)
+      http_parser.rb (~> 0.6.0)
+      json (~> 1.8)
+      memoizable (~> 0.4.0)
+      naught (~> 1.0)
+      simple_oauth (~> 0.3.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  logger
+  mysql2
+  twitter


### PR DESCRIPTION
This PR adds a Gemfile and associated lockfile for the Ruby daemon; this was done to

1. predict and control the dependencies for said daemon, and
2. assist tools for setting up e.g. development environments.

The lockfile locks the Ruby daemon's environment to the latest releases of `twitter`, `mysql2`, and `logger`.