### PR TITLE
Updating #! for server.rb to use /usr/bin/env for portability.

### DIFF
--- a/bin/server.rb
+++ b/bin/server.rb
@@ -1,4 +1,4 @@
-#!/usr/local/bin/ruby
+#!/usr/bin/env ruby
 
 require 'socket'
 require 'twitter'


### PR DESCRIPTION
Since ruby is installed in a different path on my system, I've had to update server.rb for testing. This will eliminate the need for that.

Please verify on the OAPI server that /usr/bin/env ruby will work prior to merging:

```
$ /usr/bin/env ruby -v
ruby 1.9.3p0 (2011-10-30 revision 33570) [i686-linux]
```